### PR TITLE
fix Not enough arguments in call to ti.Portfolio

### DIFF
--- a/cmd/portfolio/main.go
+++ b/cmd/portfolio/main.go
@@ -19,7 +19,7 @@ func main() {
 		return
 	}
 	ti := sdk.NewRestClient(apiKey)
-	positions, err := ti.Portfolio(context.Background())
+	positions, err := ti.Portfolio(context.Background(), sdk.DefaultAccount)
 	if err != nil {
 		log.Fatalf("failed to get portfolio: %v", err)
 		return


### PR DESCRIPTION
GoLand подсвечивает как error 
![image](https://user-images.githubusercontent.com/6348215/75606970-e13f2080-5b0b-11ea-84fa-20f065f952c5.png)


сделал по примеру из https://github.com/TinkoffCreditSystems/invest-openapi-go-sdk/blob/b634de5388d0cbfaf206012dfc34c0f05cc1a597/examples/main.go#L125